### PR TITLE
Add Benchmark Results - 2019 x86 MacBook Pro, 2022 MacBook Pro M1

### DIFF
--- a/results/macOS-12.6.3/2023-02-15-MacBookPro17,1-671404.md
+++ b/results/macOS-12.6.3/2023-02-15-MacBookPro17,1-671404.md
@@ -1,0 +1,27 @@
+# macOS 12.6.3 arm64
+* Script executed : 2023-02-15
+* Script version  : 1.1.3 - Feb 15 07:48:14 2023
+* Hardware details: MacBookPro17,1 - 8 CPUs - 16 GiB RAM -  Apple M1 GPU
+* CPU details     : Apple M1
+* OS Details      : macOS 12.6.3
+* OS Install date : 2022-12-14
+* all indexes     : Apple Mac Mini M1 2020 8GB = 100%
+ 
+## BENCHMARK XFADE
+* task: generating a cross-fade video with ffmpeg: 5 secs @ 10 fps
+* image dimensions: 4288x2848
+* program: /opt/homebrew/bin/ffmpeg - ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+* Max CPU: 501.4
+* output size: 6148 KB
+* benchmark finished after: 49 secs
+* performance index: 153.06 %
+ 
+## BENCHMARK PRIMITIVE
+* task: generating a primitive sequence: width: 1200 px / 1000 shapes
+* program: /Users/tammycravit/go/bin/primitive (fogleman/primitive)
+* Max CPU: 559.7
+* output size: 5184 KB
+* benchmark finished after: 83 secs
+* performance index: 114.46 %
+ 
+* Combined performance index: 132 %

--- a/results/macOS-13.2/2023-02-15-MacBookPro16,1-75d6fe.md
+++ b/results/macOS-13.2/2023-02-15-MacBookPro16,1-75d6fe.md
@@ -1,0 +1,32 @@
+# macOS 13.2 i386
+* Script executed : 2023-02-15
+* Script version  : 1.1.3 -   File: "/Users/tammy/m1_benchmark/m1_benchmark.sh"
+    ID: 10000070000001a Namelen: ?       Type: apfs
+Block size: 4096       Fundamental block size: 4096
+Blocks: Total: 488475719  Free: 170826010  Available: 170826010
+Inodes: Total: 6842287539 Free: 6833040400
+* Hardware details: MacBookPro16,1 - 12 CPUs - 32 GiB RAM -  Intel UHD Graphics 630
+ AMD Radeon Pro 5500M GPU
+* CPU details     : Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+* OS Details      : macOS 13.2
+* OS Install date : 2022-04-12
+* all indexes     : Apple Mac Mini M1 2020 8GB = 100%
+ 
+## BENCHMARK XFADE
+* task: generating a cross-fade video with ffmpeg: 5 secs @ 10 fps
+* image dimensions: 4288x2848
+* program: /usr/local/bin/ffmpeg - ffmpeg version 5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
+* Max CPU: 838.6
+* output size: 6148 KB
+* benchmark finished after: 72 secs
+* performance index: 104.17 %
+ 
+## BENCHMARK PRIMITIVE
+* task: generating a primitive sequence: width: 1200 px / 1000 shapes
+* program: /Users/tammy/go/bin/primitive (fogleman/primitive)
+* Max CPU: 1000.2
+* output size: 6208 KB
+* benchmark finished after: 219 secs
+* performance index: 43.38 %
+ 
+* Combined performance index: 67 %


### PR DESCRIPTION
Add benchmark results for the following systems:
- 2019 MacBook Pro 16 inch (x86_64),12 cores, 32 GB RAM, macOS 13.2
- 2022 MacBook Pro 13 inch (M1), 8 cores, 16 GB RAM, macOS 12.6.3